### PR TITLE
Fix sampleRefraction: calc ray.origin

### DIFF
--- a/pathtracing_sandbox.html
+++ b/pathtracing_sandbox.html
@@ -390,6 +390,7 @@ void sampleRefraction(vec2 Xi, inout Intersection intersection, inout Ray ray, v
 
 	if ( refractDirection == vec3( 0.0 ) ) {
 		// 完全反射のケース
+		ray.origin = intersection.position + OFFSET * orientingNormal;
 		ray.direction = reflectDirection;
 	} else {
 		// フレネル反射率Rの計算
@@ -403,12 +404,13 @@ void sampleRefraction(vec2 Xi, inout Intersection intersection, inout Ray ray, v
 
 		if ( Xi.x <= R ) {
 			// 反射
+			ray.origin = intersection.position + OFFSET * orientingNormal;
 			ray.direction = reflectDirection;
 		} else {
 			// 屈折
 			// 物体内部にレイの原点を移動する
 			//intersection.material.color *= pow( nnt, 2.0 );// 立体角の変化に伴う放射輝度の補正を入れたら暗くなったのでコメントアウト
-			ray.origin = intersection.position - OFFSET * intersection.normal;
+			ray.origin = intersection.position - OFFSET * orientingNormal;
 			ray.direction = refractDirection;
 		}
 	}


### PR DESCRIPTION
refs https://github.com/gam0022/hanamaru-renderer/commit/7d53aa5f8e9f9feaf42a0f93ee6e92253c3138fa

屈折時のレイの原点の計算が間違っていました。
物体内部から物体外の向きのレイの考慮が抜けていました。